### PR TITLE
Fix tags list on posts.

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -3,7 +3,7 @@
 {{ if gt $tagsLen 0 }}
 <div class="post-tags">
   {{ range $k, $v := $.Params.tags }}
-  <a href="{{ ($.Site.GetPage "taxonomyTerm" "tags" .).Permalink }}">{{ . }}</a>
+  <a href="{{ (printf "%s/%s" ($.Site.GetPage "tags").Permalink $v) | relURL }}">{{ . }}</a>
   {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
Uses non-deprecated `GetPage` call. See release notes for [Hugo 0.45](https://github.com/gohugoio/hugo/releases/tag/v0.45) for further information.

I'm a complete newb to both Hugo, this theme, and half the languages used. So if I've screwed something up or misunderstood some underlying concept, please let me know. Thanks!