### PR TITLE
Append noreferrer to rel in order to patch vulnerability in older FF versions

### DIFF
--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -4,21 +4,21 @@
     <li>
       <a class="twitter"
          href="https://twitter.com/intent/tweet?text={{ .Title | html }}&amp;url={{ .Permalink | html }}"
-         target="_blank" rel="noopener">
+         target="_blank" rel="noopener noreferrer">
         <i class="fa fa-twitter"></i>
       </a>
     </li>
     <li>
       <a class="facebook"
          href="https://www.facebook.com/sharer.php?u={{ .Permalink | html }}"
-         target="_blank" rel="noopener">
+         target="_blank" rel="noopener noreferrer">
         <i class="fa fa-facebook"></i>
       </a>
     </li>
     <li>
       <a class="linkedin"
          href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ .Permalink | html }}&amp;title={{ .Title | html }}"
-         target="_blank" rel="noopener">
+         target="_blank" rel="noopener noreferrer">
         <i class="fa fa-linkedin"></i>
       </a>
     </li>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -15,7 +15,7 @@
       </li>
       {{ range $.Site.Params.social }}
       <li>
-        <a itemprop="sameAs" href="{{ .link | safeURL }}" target="_blank" rel="noopener">
+        <a itemprop="sameAs" href="{{ .link | safeURL }}" target="_blank" rel="noopener noreferrer">
           <i class="fa fa-{{ .icon }}"></i>
           {{ .text }}
         </a>


### PR DESCRIPTION
This add `noreferrer` to the rel of anchor with `target="_blank"`

While this is not [an issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1222516) for newer version of Firefox, I felt it couldn't hurt to add this to cover older versions of Firefox 