### PR TITLE
Allows the user to modify navigation header from config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -94,20 +94,20 @@ enableGitInfo = false
 
   # Header menu links
   [[params.menu]]
-    label = "Home"
-    url = "/"
+    link = "/"
+    text = "Home"
 
   [[params.menu]]
-    label = "Projects"
-    url = "/projects"
+    link = "/projects"
+    text = "Projects"
 
   [[params.menu]]
-    label = "Blog"
-    url = "/blog"
+    link = "/blog"
+    text = "Blog"
 
   [[params.menu]]
-    label = "About"
-    url = "/about"
+    link = "/about"
+    text = "About"
 
 # Taxonomies.
 # [taxonomies]

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -94,19 +94,19 @@ enableGitInfo = false
 
   # Header menu links
   [[params.menu]]
-    name = "Home"
+    label = "Home"
     url = "/"
 
   [[params.menu]]
-    name = "Projects"
+    label = "Projects"
     url = "/projects"
 
   [[params.menu]]
-    name = "Blog"
+    label = "Blog"
     url = "/blog"
 
   [[params.menu]]
-    name = "About"
+    label = "About"
     url = "/about"
 
 # Taxonomies.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -66,6 +66,8 @@ enableGitInfo = false
   #   Anonymize IP in Google Analytics (if enabled)
   privacy_pack = false
 
+  # Social links
+  # Shown in sidebar, icons from Font Awesome
   [[params.social]]
     icon = "instagram"
     icon_pack = "fa"
@@ -89,6 +91,23 @@ enableGitInfo = false
     icon_pack = "fa"
     link = "//github.com/jhu247"
     text = "Github"
+
+  # Header menu links
+  [[params.menu]]
+    name = "Home"
+    url = "/"
+
+  [[params.menu]]
+    name = "Projects"
+    url = "/projects"
+
+  [[params.menu]]
+    name = "Blog"
+    url = "/blog"
+
+  [[params.menu]]
+    name = "About"
+    url = "/about"
 
 # Taxonomies.
 # [taxonomies]

--- a/layouts/partials/masthead_nav.html
+++ b/layouts/partials/masthead_nav.html
@@ -2,7 +2,7 @@
 	<nav>
 		{{ range $k, $v := $.Site.Params.menu }}
 			{{ if $k }}&nbsp&nbsp•&nbsp&nbsp{{ end }}
-			<a href="{{ $v.url | relURL }}">{{ $v.label }}</a>
+			<a href="{{ $v.link | relURL }}">{{ $v.text }}</a>
 		{{ end }}
 	</nav>
 </div>

--- a/layouts/partials/masthead_nav.html
+++ b/layouts/partials/masthead_nav.html
@@ -1,8 +1,8 @@
 <div class="navbar-hero">
 	<nav>
-		<a href="/">Home</a>&nbsp&nbsp•&nbsp&nbsp
-		<a href="/projects">Projects</a>&nbsp&nbsp•&nbsp&nbsp
-		<a href="/blog">Blog</a>&nbsp&nbsp•&nbsp&nbsp
-		<a href="/about">About</a>
+		{{ range $i, $e := $.Site.Params.menu }}
+			{{ if $i }}&nbsp&nbsp•&nbsp&nbsp{{ end }}
+			<a href="{{ $e.url | relURL }}">{{ $e.name }}</a>
+		{{ end }}
 	</nav>
 </div>

--- a/layouts/partials/masthead_nav.html
+++ b/layouts/partials/masthead_nav.html
@@ -1,8 +1,8 @@
 <div class="navbar-hero">
 	<nav>
-		{{ range $i, $e := $.Site.Params.menu }}
-			{{ if $i }}&nbsp&nbsp•&nbsp&nbsp{{ end }}
-			<a href="{{ $e.url | relURL }}">{{ $e.name }}</a>
+		{{ range $k, $v := $.Site.Params.menu }}
+			{{ if $k }}&nbsp&nbsp•&nbsp&nbsp{{ end }}
+			<a href="{{ $v.url | relURL }}">{{ $v.label }}</a>
 		{{ end }}
 	</nav>
 </div>


### PR DESCRIPTION
This commit implements the request from #11 to allow the user to modify the header navigation links from the `config.toml` file.